### PR TITLE
Use consume instead of basic_consume in rabbitmq worker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class PyTest(TestCommand):
 setup(
     name='easy_job',
     packages=setuptools.find_packages(exclude=['tests', 'tests.*']),
-    version='0.2.4',
+    version='0.2.5',
     description='A lightweight background task runner',
     author='Mahdi Zareie',
     install_requires=["retrying",


### PR DESCRIPTION
There was a slightly small problem with heartbeats